### PR TITLE
Do not create server and signer users with ALL PRIVILEGES

### DIFF
--- a/make/photon/db/initial-notaryserver.sql
+++ b/make/photon/db/initial-notaryserver.sql
@@ -1,4 +1,1 @@
 CREATE DATABASE notaryserver;
-CREATE USER server;
-alter user server with encrypted password 'password';
-GRANT ALL PRIVILEGES ON DATABASE notaryserver TO server;

--- a/make/photon/db/initial-notarysigner.sql
+++ b/make/photon/db/initial-notarysigner.sql
@@ -1,4 +1,1 @@
 CREATE DATABASE notarysigner;
-CREATE USER signer;
-alter user signer with encrypted password 'password';
-GRANT ALL PRIVILEGES ON DATABASE notarysigner TO signer;


### PR DESCRIPTION
These users are not necessary for production environment
deployed by the helm chart, as they are not used to access the
notary databases.

(cherry picked from commit 595693fe1ecfa2bc757c839f548aae73aaf5c829)